### PR TITLE
Add compatibility with browserify 3

### DIFF
--- a/inflate.js
+++ b/inflate.js
@@ -318,7 +318,7 @@ exports.inflate = function (input) {
     function GET_BYTE() {
         if(inflate_data.length == inflate_pos)
         return -1;
-        return inflate_data.get(inflate_pos++);
+        return inflate_data.readUInt8(inflate_pos++);
     }
 
     function NEEDBITS(n) {

--- a/zip.js
+++ b/zip.js
@@ -423,14 +423,14 @@ Entry.prototype.getMode = function () {
 var bytesToNumberLE = function (bytes) {
     var acc = 0;
     for (var i = 0; i < bytes.length; i++)
-        acc += bytes.get(i) << (8*i);
+        acc += bytes.readUInt8(i) << (8*i);
     return acc;
 };
 
 var bytesToNumberBE = function (bytes) {
     var acc = 0;
     for (var i = 0; i < bytes.length; i++)
-        acc = (acc << 8) + bytes.get(i);
+        acc = (acc << 8) + bytes.readUInt8(i);
     return acc;
 };
 


### PR DESCRIPTION
Two fixes to allow zip to run under browserify 3.19.0:
1. isBuffer() check, per https://npmjs.org/package/native-buffer-browserify
   
   > Use Buffer.isBuffer instead of instanceof Buffer. The Buffer constructor returns a Uint8Array (as discussed above) for performance reasons, so instanceof Buffer won't work. In node Buffer.isBuffer just does instanceof Buffer, but in browserify we use a Buffer.isBuffer shim that detects our special Uint8Array-based Buffers.
2. readUInt8() instead of get() on Buffer. Seems this method is available but undocumented http://nodejs.org/api/buffer.html in NodeJS (tested on 0.10.21), but in native-buffer-browserify it is not available and readUInt8 is equivalent (on both platforms)
