### PR TITLE
Fix issue with files > 8192 bytes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ node_js:
   - 6
   - 5
   - 4
-  - "0.10"
 
 before_install:
   - 'npm install -g npm@latest'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
   - 6
   - 5
   - 4
-  - 0.10
+  - "0.10"
 
 before_install:
   - 'npm install -g npm@latest'

--- a/zip.js
+++ b/zip.js
@@ -27,8 +27,8 @@ function FdSource(fd) {
 	}
 	this.read = function(start, length) {
 		var result = bops.create(length);
+		var pos = 0;
 		while (length > 0) {
-			var pos = 0;
 			var toRead = length > 8192? 8192: length;
 			fs.readSync(fd, result, pos, toRead, start);
 			length -= toRead;


### PR DESCRIPTION
When a ZIP file is greater than 8192 bytes the original logic was overwriting the same part of the buffer, solution is to move the initialisation of the `pos`  variable outside the read loop.